### PR TITLE
add insights-client RPM

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 insights-client
 ========
 
-Installs, configures, and registers a system to the [Red Hat Insights service](http://access.redhat.com/insights).  This role is intended to work on Red Hat Enterprise Linux, though it will generally work on any yum based system that has access to the redhat-access-insights RPM.
+Installs, configures, and registers a system to the [Red Hat Insights service](http://access.redhat.com/insights).  This role is intended to work on Red Hat Enterprise Linux, though it will generally work on any yum based system that has access to the insights-client RPM or the redhat-access-insights RPM.
 
 Requirements
 ------------

--- a/examples/example-insights-client-playbook.yml
+++ b/examples/example-insights-client-playbook.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   roles:
   - { role: RedHatInsights.insights-client }

--- a/files/insights.fact
+++ b/files/insights.fact
@@ -14,7 +14,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-if [ -e /etc/redhat-access-insights/machine-id ]; then
+if [ -e /etc/insights-client/machine-id ]; then
+    SYSTEM_ID=$(cat /etc/insights-client/machine-id)
+elif [ -e /etc/redhat-access-insights/machine-id ]; then
     SYSTEM_ID=$(cat /etc/redhat-access-insights/machine-id)
 fi
 if [ -n "${SYSTEM_ID}" ]; then

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,16 @@
 ---
 galaxy_info:
-    author: Red Hat, Inc
-    description: Install and configure Red Hat Insights Client
-    company: Red Hat, Inc.
-    license: Apache License 2.0
-    min_ansible_version: 1.2
-    platforms:
+  author: Red Hat, Inc
+  description: Install and configure Red Hat Insights Client
+  company: Red Hat, Inc.
+  license: Apache License 2.0
+  min_ansible_version: 1.2
+  platforms:
     - name: EL
       versions:
-      - 6
-      - 7
-    categories:
+        - 6
+        - 7
+  categories:
     - packaging
     - system
-    dependencies: []
+  dependencies: []

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -1,0 +1,65 @@
+Testing insights-client role with Molecule
+==========================================
+
+The role uses [Molecule](https://github.com/metacloud/molecule) for testing.  See below
+for installing and running Molecule.
+
+Because of what this role is intended to do, in order to test this role, you need a copy
+of Red Hat Enterprise Linux and a subscription to the
+[Red Hat Insights service](http://access.redhat.com/insights) service.
+
+Here Molecule is configured to test this role on three libvirt Vagrant boxes named
+'rhel68-base', 'rhel72-base', and 'rhel74-base'.  The number or names of the boxes tested
+by the default scenario can be changed by editing the 'platforms' section
+of the 'molecule/default/molecule.yml' file.  The names can be arbitrary as long as they refer
+to Vagrant boxes available on the test machine.  The command 'vagrant box list' will tell you
+which boxes are available on the test machine.  The tests should work for any currently supported
+version of RHEL.
+
+Vagrant boxes for RHEL are not generally available, though both Red Hat Developer Support and
+Red Hat Support sites have instructions for creating Vagrant boxes from RHEL images.
+
+Since this role actually registers with the Insights service, the test boxes must register
+with the Red Hat Portal.  Portal credentials must be supplied in the file
+'~/redhat-portal-creds.yml', in the format described below.
+
+
+Installing Molecule
+-------------------
+
+The easiest way to install Molecule at the point of writing this, is to use a Python virtual environment and pip.
+
+    ```bash
+    $ virtualenv --no-site-packages .venv
+    $ source .venv/bin/activate
+    $ pip install molecule ansible python-vagrant
+    ```
+
+Review or Edit the file 'molecule/default/molecule.yml'
+-------------------------------------------------------
+
+Make sure the boxes specified in the 'platforms' section are boxes that are actually available
+on the test machine.
+
+Review or Edit the portal creds file: ~/redhat-portal-creds.yml
+-------------------------------------------------------
+
+Create a YAML file, ~/redhat-portal-creds.yml, on the test machine containing the following,
+with XXXXXX/YYYYYY replaced with our Insights/Portal/RHSM username/password:
+
+    redhat_portal_username: XXXXXX
+    redhat_portal_password: YYYYYY
+
+Run the molecule test
+---------------------
+
+    ```bash
+    $ molecule test
+    ```
+
+or if you need more details from the error messages:
+
+    ```bash
+    $ molecule test --debug
+    ```
+

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,17 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+* python-vagrant
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install python-vagrant

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -1,0 +1,60 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  tasks:
+    - name: Create molecule instance(s)
+      molecule_vagrant:
+        instance_name: "{{ item.name }}"
+        instance_interfaces: "{{ item.interfaces | default(omit) }}"
+        instance_raw_config_args: "{{ item.instance_raw_config_args | default(omit) }}"
+
+        config_options: "{{ item.config_options | default(omit) }}"
+
+        platform_box: "{{ item.box }}"
+        platform_box_version: "{{ item.box_version | default(omit) }}"
+        platform_box_url: "{{ item.box_url | default(omit) }}"
+
+        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_memory: "{{ item.memory | default(omit) }}"
+        provider_cpus: "{{ item.cpus | default(omit) }}"
+        provider_options: "{{ item.provider_options | default(omit) }}"
+        provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
+
+        provision: "{{ item.provision | default(omit) }}"
+
+        state: up
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+
+    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance creation
+    # causes issues.
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.Host }}",
+          'address': "{{ item.HostName }}",
+          'user': "{{ item.User }}",
+          'port': "{{ item.Port }}",
+          'identity_file': "{{ item.IdentityFile }}", }
+      with_items: "{{ server.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      molecule_vagrant:
+        instance_name: "{{ item.name }}"
+        platform_box: "{{ item.box }}"
+        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        force_stop: "{{ item.force_stop | default(true) }}"
+
+        state: destroy
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+
+    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance deletion
+    # causes issues.
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+lint:
+  name: yamllint
+platforms:
+  - name: instance-rhel72
+    box: rhel72-base
+  - name: instance-rhel74
+    box: rhel74-base
+  - name: instance-rhel68
+    box: rhel68-base
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+
+    - name: Invoke role insights-client-role
+      import_role:
+        name: insights-client-role
+
+    - name: Un-register from RHSM
+      redhat_subscription:
+        state: absent
+      when: ansible_distribution == "RedHat"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+
+    - name: Install libselinux-python, Ansible clients need this on RHEL
+      package:
+        name: libselinux-python
+      when: ansible_distribution == "RedHat"
+
+    - name: Pull in the Red Hat Portal credentials from home directory
+      include_vars:
+        file: "~/redhat-portal-creds.yml"
+
+    - name: Register with and autosubscribe to RHSM
+      redhat_subscription:
+        username: "{{ redhat_portal_username }}"
+        password: "{{ redhat_portal_password }}"
+        autosubscribe: true
+        state: present
+      when: ansible_distribution == "RedHat"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,17 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    if host.package('insights-client').is_installed:
+        insights_name = 'insights-client'
+    else:
+        insights_name = 'redhat-access-insights'
+
+    insights_conf_file = '/etc/'+insights_name+'/'+insights_name+'.conf'
+    assert host.package(insights_name).is_installed
+    assert host.file(insights_conf_file).exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,31 +18,31 @@
   yum:
     list: insights-client
   register: yum_list_task
-  become: yes
+  become: true
 
 - name: Install 'insights-client' if it is available
   yum:
     name: insights-client
   when: yum_list_task.results|length > 0
-  become: yes
+  become: true
 
 - name: Set Insights Config Name to 'insights-client'
   set_fact:
     insights_name: 'insights-client'
   when: yum_list_task.results|length > 0
-  become: yes
+  become: true
 
 - name: Install 'redhat-access-insights' if 'insights-client' is not available
   yum:
     name: redhat-access-insights
   when: yum_list_task.results|length == 0
-  become: yes
+  become: true
 
 - name: Set Insights Config Name to 'redhat-access-insights'
   set_fact:
     insights_name: 'redhat-access-insights'
   when: yum_list_task.results|length == 0
-  become: yes
+  become: true
 
 - name: Configure username in Insights' Config file
   ini_file:
@@ -50,10 +50,10 @@
     section: "{{ insights_name }}"
     option: username
     value: "{{ redhat_portal_username }}"
-    no_extra_spaces: yes
+    no_extra_spaces: true
     state: "{{ 'present' if redhat_portal_username else 'absent' }}"
   when: redhat_portal_username is defined
-  become: yes
+  become: true
 
 - name: Configure password in Insights Config file
   ini_file:
@@ -64,11 +64,11 @@
     no_extra_spaces: true
     state: "{{ 'present' if redhat_portal_username else 'absent' }}"
   when: redhat_portal_username is defined
-  become: yes
+  become: true
 
 - name: Check status of Insights .register file
   stat: path=/etc/{{ insights_name }}/.registered
-  become: yes
+  become: true
   register: reg_file_task
 
 - name: Unregister if we are setting the display_name, and we have already registered
@@ -76,44 +76,35 @@
   when:
     - insights_display_name is defined
     - reg_file_task.stat.exists == true
-  become: yes
+  become: true
 
-- name: Register to the Red Hat Access Insights Service
-  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }}"
-  ignore_errors: yes
-  become: yes
-  # Always run --register (see next comment for why)
-
-- name: Register to Insights again if necessary
+- name: Register to the Red Hat Access Insights Service if necessary
   command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }} creates=/etc/{{ insights_name }}/.registered"
-  become: yes
-  # Only run --register again if there is no .register file at this point
-  #   This is to handle the case where the system was unregistered on the server, but this
-  #   system hasn't noticed and removed the .registered file
+  become: true
 
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
   file:
     path: /etc/{{ insights_name }}
     mode: og=rx
-  become: yes
+  become: true
 
 - name: Change permissions of machine_id file so that Insights System ID can be read
   file:
     path: /etc/{{ insights_name }}/machine-id
     mode: og=r
-  become: yes
+  become: true
 
 
 - name: Create directory for ansible custom facts
   file:
     state: directory
-    recurse: yes
+    recurse: true
     path: /etc/ansible/facts.d
-  become: yes
+  become: true
 
 - name: Install custom insights fact
   copy:
     src: insights.fact
     dest: /etc/ansible/facts.d
     mode: a+x
-  become: yes
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,50 +14,78 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-- name: Install Red Hat Access Insights Client
-  yum: name=redhat-access-insights state=present
+- name: Check for 'insights-client' RPM availability
+  yum:
+    list: insights-client
+  register: yum_list_task
   become: yes
 
-- name: Configure username in redhat-access-insights.conf
+- name: Install 'insights-client' if it is available
+  yum:
+    name: insights-client
+  when: yum_list_task.results|length > 0
+  become: yes
+
+- name: Set Insights Config Name to 'insights-client'
+  set_fact:
+    insights_name: 'insights-client'
+  when: yum_list_task.results|length > 0
+  become: yes
+
+- name: Install 'redhat-access-insights' if 'insights-client' is not available
+  yum:
+    name: redhat-access-insights
+  when: yum_list_task.results|length == 0
+  become: yes
+
+- name: Set Insights Config Name to 'redhat-access-insights'
+  set_fact:
+    insights_name: 'redhat-access-insights'
+  when: yum_list_task.results|length == 0
+  become: yes
+
+- name: Configure username in Insights' Config file
   ini_file:
-    path: /etc/redhat-access-insights/redhat-access-insights.conf
-    section: redhat-access-insights
+    path: /etc/{{ insights_name }}/{{ insights_name }}.conf
+    section: "{{ insights_name }}"
     option: username
     value: "{{ redhat_portal_username }}"
     no_extra_spaces: yes
     state: "{{ 'present' if redhat_portal_username else 'absent' }}"
   when: redhat_portal_username is defined
+  become: yes
 
-- name: Configure password in redhat-access-insights.conf
+- name: Configure password in Insights Config file
   ini_file:
-    path: /etc/redhat-access-insights/redhat-access-insights.conf
-    section: redhat-access-insights
+    path: /etc/{{ insights_name }}/{{ insights_name }}.conf
+    section: "{{ insights_name }}"
     option: password
     value: "{{ redhat_portal_password }}"
     no_extra_spaces: true
     state: "{{ 'present' if redhat_portal_username else 'absent' }}"
   when: redhat_portal_username is defined
+  become: yes
 
 - name: Check status of Insights .register file
-  stat: path=/etc/redhat-access-insights/.registered
+  stat: path=/etc/{{ insights_name }}/.registered
   become: yes
   register: reg_file_task
 
 - name: Unregister if we are setting the display_name, and we have already registered
-  command: redhat-access-insights --unregister
+  command: "{{ insights_name }} --unregister"
   when:
     - insights_display_name is defined
     - reg_file_task.stat.exists == true
   become: yes
 
 - name: Register to the Red Hat Access Insights Service
-  command: redhat-access-insights --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }}
+  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }}"
   ignore_errors: yes
   become: yes
   # Always run --register (see next comment for why)
 
 - name: Register to Insights again if necessary
-  command: redhat-access-insights --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }} creates=/etc/redhat-access-insights/.registered
+  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }} creates=/etc/{{ insights_name }}/.registered"
   become: yes
   # Only run --register again if there is no .register file at this point
   #   This is to handle the case where the system was unregistered on the server, but this
@@ -65,13 +93,13 @@
 
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
   file:
-    path: /etc/redhat-access-insights
+    path: /etc/{{ insights_name }}
     mode: og=rx
   become: yes
 
 - name: Change permissions of machine_id file so that Insights System ID can be read
   file:
-    path: /etc/redhat-access-insights/machine-id
+    path: /etc/{{ insights_name }}/machine-id
     mode: og=r
   become: yes
 


### PR DESCRIPTION
This change causes the role to install and configure the insights-client RPM if it available, and fall back to the redhat-access-insights RPM otherwise.