### PR TITLE
Change registration check

### DIFF
--- a/action_plugins/insights_config.py
+++ b/action_plugins/insights_config.py
@@ -1,0 +1,40 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        insights_name = self._task.args.get('insights_name')
+
+        config_vars = dict(
+            username = self._task.args.get('username', None),
+            password = self._task.args.get('password', None),
+            auto_config = self._task.args.get('auto_config', None),
+            authmethod = self._task.args.get('authmethod', None)
+        )
+
+        for k, v in config_vars.items():
+            if v:
+                new_module_args = dict(
+                    path = '/etc/' + insights_name + '/' + insights_name + '.conf',
+                    section = insights_name,
+                    option = k,
+                    value = v,
+                    no_extra_spaces = True,
+                    state = "present"
+                )
+                result.update(self._execute_module(
+                    module_name='ini_file',
+                    module_args=new_module_args,
+                    task_vars=task_vars,
+                    tmp=tmp
+                ))
+
+        return result
+

--- a/action_plugins/insights_config.py
+++ b/action_plugins/insights_config.py
@@ -10,13 +10,14 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        insights_name = self._task.args.get('insights_name')
+        insights_name = self._task.args.get('insights_name', 'insights-client')
 
         config_vars = dict(
             username = self._task.args.get('username', None),
             password = self._task.args.get('password', None),
             auto_config = self._task.args.get('auto_config', None),
-            authmethod = self._task.args.get('authmethod', None)
+            authmethod = self._task.args.get('authmethod', None),
+            display_name = self._task.args.get('display_name', None)
         )
 
         for k, v in config_vars.items():

--- a/library/insights_config.py
+++ b/library/insights_config.py
@@ -1,0 +1,49 @@
+ANSIBLE_METADATA = {
+     'metadata_version': '1.1',
+     'status': ['preview'],
+     'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: insights_config
+short_description: This module handles initial configuration of the insights client on install
+description:
+  - Supply values for various configuration options that you would like to use. On install
+  this module will add those values to the insights-client.conf file prior to registering.
+version_added: "3.0"
+options:
+  insights_name:
+    description:
+    - For now this is just 'insights-client', but that could change in the future if the
+    product name changes.
+    required: true
+  username:
+    description:
+    - Insights basic auth username. If defined this will change, set, or remove the username
+    in the insights configuration. To remove a username set this value to an empty string.
+    required: false
+  password:
+    description:
+    - Insights basic auth password. If defined this will change, set, or remove the password
+    in the insights configuration. To remove a password set this value to an empty string.
+    required: false
+  auto_config:
+    description:
+    - Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.
+    required: false
+  authmethod:
+    description:
+    - Authentication method for the Portal (BASIC, CERT). Default is BASIC. Note: when
+    auto_config is enabled, CERT will be used if RHSM or Satellite is detected.
+    required: true
+'''
+
+EXAMPLES = '''
+- insights_config:
+    insights_name: 'insights-client' or "{{ insights_name }}"
+    username: "rhn_support" or "{{ redhat_portal_username }}" if passing in as a role variable
+    password: "rhn_password" or "{{ redhat_portal_password }}" if passing in as a role variable
+    auto_config: True
+    authmethod: BASIC
+'''

--- a/library/insights_config.py
+++ b/library/insights_config.py
@@ -13,11 +13,6 @@ description:
   this module will add those values to the insights-client.conf file prior to registering.
 version_added: "3.0"
 options:
-  insights_name:
-    description:
-    - For now this is just 'insights-client', but that could change in the future if the
-    product name changes.
-    required: true
   username:
     description:
     - Insights basic auth username. If defined this will change, set, or remove the username
@@ -36,14 +31,37 @@ options:
     description:
     - Authentication method for the Portal (BASIC, CERT). Default is BASIC. Note: when
     auto_config is enabled, CERT will be used if RHSM or Satellite is detected.
-    required: true
+    required: false
+  display_name:
+    description:
+    - Custom display name to appear in the Insights web UI. Only used on machine registration.
+    Blank by default.
+    required: false
+  insights_name:
+    description:
+    - For now, this is just 'insights-client', but it could change in the future so having
+    it as a variable is just preparing for that.
+    required: false
 '''
 
 EXAMPLES = '''
-- insights_config:
-    insights_name: 'insights-client' or "{{ insights_name }}"
-    username: "rhn_support" or "{{ redhat_portal_username }}" if passing in as a role variable
-    password: "rhn_password" or "{{ redhat_portal_password }}" if passing in as a role variable
-    auto_config: True
-    authmethod: BASIC
+- name: Configure the insights client to register with username and password
+    insights_config:
+      username: "rhn_support" or "{{ redhat_portal_username }}" if passing in as a role variable
+      password: "rhn_password" or "{{ redhat_portal_password }}"
+      auto_config: False or "{{ auto_config }}"
+      authmethod: BASIC or "{{ authmethod }}"
+  become: true
+
+- name: Configure the insights client to register with RHSM and no display name
+    insights_config:
+  become: true
+
+Note: The above example calls the insights_config module with no parameters. This is because auto_config defaults to True
+which in turn forces the client to try RHSM (or Satellite)
+
+- name: Configure the insights client to register with RHSM and a display name
+    insights_config:
+      display_name: "nice_name" or "{{ insights_display_name }}" if passing in as a role variable
+  become: true
 '''

--- a/library/insights_register.py
+++ b/library/insights_register.py
@@ -38,9 +38,10 @@ options:
         required: false
     force_reregister:
         description:
-        - This option should be set to true if you wish to force a reregister of the insights-client.
-        Note that this will remove the existing machine-id and create a new one. Only use this option
-        if you are okay with creating a new machine-id.
+            - This option should be set to true if you wish to force a reregister of the insights-client.
+            Note that this will remove the existing machine-id and create a new one. Only use this option
+            if you are okay with creating a new machine-id.
+        required: false
 
 author:
     - Jason Stephens (@Jason-RH)

--- a/library/insights_registration.py
+++ b/library/insights_registration.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: insights_registration
+
+short_description: This module registers the insights client
+
+description:
+    - This module will check the current registration status, unregister if needed,
+    and then register the insights client (and update the display_name if needed)
+
+options:
+    insights_name:
+        description:
+            - For now, this is just 'insights-client', but it could change in the future
+            so having it as a variable is just preparing for that
+        required: true
+    display_name:
+        description:
+            - When registering with insights an optional display_name can be configured
+        required: false
+
+author:
+    - Jason Stephens (@Jason-RH)
+'''
+
+EXAMPLES = '''
+# Register a fresh install
+- name: Register the insights client on a fresh install
+  insights_registration:
+    insights_name: "{{ insights_name }}"
+
+# Register a fresh install with a display name
+- name: Register the insights client with display name
+  insights_registration:
+    insights_name: "{{ insights_name }}"
+    display_name: "{{ insights_display_name }}"
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+message:
+    description: The output message that the sample module generates
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import subprocess
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        insights_name=dict(type='str', required=True),
+        display_name=dict(type='str', required=False, default='')
+    )
+
+    result = dict(
+        changed=False,
+        original_message='',
+        message=''
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        return result
+
+    result['original_message'] = 'Attempting to register insights-client'
+    result['message'] = 'No registration changes have been made'
+
+    insights_name = module.params['insights_name']
+    display_name = module.params['display_name']
+
+    reg_status = subprocess.call([insights_name, '--status'])
+
+    if display_name and reg_status is 0:
+        subprocess.call([insights_name, '--unregister'])
+        reg_status = 1
+        result['changed'] = True
+        result['message'] = 'Insights-client has been unregistered'
+
+    if reg_status is not 0:
+        display_name_arg = '--display-name=' + display_name
+        subprocess.call([insights_name, '--register', display_name_arg])
+        result['changed'] = True
+        result['message'] = 'Insights-client has been registered'
+
+    module.exit_json(**result)
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,35 +19,28 @@
     name: insights-client
   become: true
 
-- name: Set Insights Config Name to 'insights-client'
-  set_fact:
-    insights_name: 'insights-client'
-  become: true
-
 - name: Set Insights Configuration Values
   insights_config:
-    insights_name: 'insights-client'
     username: "{{ redhat_portal_username }}"
     password: "{{ redhat_portal_password }}"
     auto_config: "{{ auto_config }}"
     authmethod: "{{ authmethod }}"
+    display_name: "{{ insights_display_name }}"
   become: true
 
 - name: Register Insights Client
-  insights_registration:
-    insights_name: "{{ insights_name }}"
-    display_name: "{{ insights_display_name if insights_display_name is defined else '' }}"
+  insights_register:
   become: true
   
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
   file:
-    path: /etc/{{ insights_name }}
+    path: /etc/insights-client
     mode: og=rx
   become: true
 
 - name: Change permissions of machine_id file so that Insights System ID can be read
   file:
-    path: /etc/{{ insights_name }}/machine-id
+    path: /etc/insights-client/machine-id
     mode: og=r
   become: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,8 +77,10 @@
 
 - name: Unregister if we are setting the display_name, and we have already registered
   block:
-    - command: "{{ insights_name }} --unregister"
-    - set_fact:
+    - name: Unregister to update display name
+      command: "{{ insights_name }} --unregister"
+    - name: Update registration status
+      set_fact:
         reg_status: "unregistered"
   when:
     - insights_display_name is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,34 +14,14 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-- name: Check for 'insights-client' RPM availability
-  yum:
-    list: insights-client
-  register: yum_list_task
-  become: true
-
-- name: Install 'insights-client' if it is available
+- name: Install 'insights-client'
   yum:
     name: insights-client
-  when: yum_list_task.results|length > 0
   become: true
 
 - name: Set Insights Config Name to 'insights-client'
   set_fact:
     insights_name: 'insights-client'
-  when: yum_list_task.results|length > 0
-  become: true
-
-- name: Install 'redhat-access-insights' if 'insights-client' is not available
-  yum:
-    name: redhat-access-insights
-  when: yum_list_task.results|length == 0
-  become: true
-
-- name: Set Insights Config Name to 'redhat-access-insights'
-  set_fact:
-    insights_name: 'redhat-access-insights'
-  when: yum_list_task.results|length == 0
   become: true
 
 - name: Configure username in Insights' Config file
@@ -104,7 +84,6 @@
     path: /etc/{{ insights_name }}/machine-id
     mode: og=r
   become: true
-
 
 - name: Create directory for ansible custom facts
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,26 +24,13 @@
     insights_name: 'insights-client'
   become: true
 
-- name: Configure username in Insights' Config file
-  ini_file:
-    path: /etc/{{ insights_name }}/{{ insights_name }}.conf
-    section: "{{ insights_name }}"
-    option: username
-    value: "{{ redhat_portal_username }}"
-    no_extra_spaces: true
-    state: "{{ 'present' if redhat_portal_username else 'absent' }}"
-  when: redhat_portal_username is defined
-  become: true
-
-- name: Configure password in Insights Config file
-  ini_file:
-    path: /etc/{{ insights_name }}/{{ insights_name }}.conf
-    section: "{{ insights_name }}"
-    option: password
-    value: "{{ redhat_portal_password }}"
-    no_extra_spaces: true
-    state: "{{ 'present' if redhat_portal_username else 'absent' }}"
-  when: redhat_portal_username is defined
+- name: Set Insights Configuration Values
+  insights_config:
+    insights_name: 'insights-client'
+    username: "{{ redhat_portal_username }}"
+    password: "{{ redhat_portal_password }}"
+    auto_config: "{{ auto_config }}"
+    authmethod: "{{ authmethod }}"
   become: true
 
 - name: Register Insights Client

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,11 +21,11 @@
 
 - name: Set Insights Configuration Values
   insights_config:
-    username: "{{ redhat_portal_username }}"
-    password: "{{ redhat_portal_password }}"
-    auto_config: "{{ auto_config }}"
-    authmethod: "{{ authmethod }}"
-    display_name: "{{ insights_display_name }}"
+    username: "{{ redhat_portal_username | default(omit) }}"
+    password: "{{ redhat_portal_password | default(omit) }}"
+    auto_config: "{{ auto_config | default(omit) }}"
+    authmethod: "{{ authmethod | default(omit) }}"
+    display_name: "{{ insights_display_name | default(omit) }}"
   become: true
 
 - name: Register Insights Client

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,33 +46,12 @@
   when: redhat_portal_username is defined
   become: true
 
-- name: Check status of Insights registration via API
-  command: "{{ insights_name }} --status"
-  register: api_status_result
+- name: Register Insights Client
+  insights_registration:
+    insights_name: "{{ insights_name }}"
+    display_name: "{{ insights_display_name if insights_display_name is defined else '' }}"
   become: true
   
-- name: Assign registration status to variable
-  set_fact:
-    reg_status: "{{ api_status_result.stderr }}"
-
-- name: Unregister if we are setting the display_name, and we have already registered
-  block:
-    - name: Unregister to update display name
-      command: "{{ insights_name }} --unregister"
-    - name: Update registration status
-      set_fact:
-        reg_status: "unregistered"
-  when:
-    - insights_display_name is defined
-    - '"Insights API confirms registration." in reg_status'
-  become: true
-
-- name: Register to the Red Hat Access Insights Service if necessary
-  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }}"
-  when:
-    - '"Insights API confirms registration." not in reg_status'
-  become: true
-
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
   file:
     path: /etc/{{ insights_name }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,20 +66,29 @@
   when: redhat_portal_username is defined
   become: true
 
-- name: Check status of Insights .register file
-  stat: path=/etc/{{ insights_name }}/.registered
+- name: Check status of Insights registration via API
+  command: "{{ insights_name }} --status"
+  register: api_status_result
   become: true
-  register: reg_file_task
+  
+- name: Assign registration status to variable
+  set_fact:
+    reg_status: "{{ api_status_result.stderr }}"
 
 - name: Unregister if we are setting the display_name, and we have already registered
-  command: "{{ insights_name }} --unregister"
+  block:
+    - command: "{{ insights_name }} --unregister"
+    - set_fact:
+        reg_status: "unregistered"
   when:
     - insights_display_name is defined
-    - reg_file_task.stat.exists == true
+    - '"Insights API confirms registration." in reg_status'
   become: true
 
 - name: Register to the Red Hat Access Insights Service if necessary
-  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }} creates=/etc/{{ insights_name }}/.registered"
+  command: "{{ insights_name }} --register {{ '--display-name='+insights_display_name if insights_display_name is defined else '' }}"
+  when:
+    - '"Insights API confirms registration." not in reg_status'
   become: true
 
 - name: Change permissions of Insights Config directory so that Insights System ID can be read

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
 
 - name: Register Insights Client
   insights_register:
+    state: present
   become: true
   
 - name: Change permissions of Insights Config directory so that Insights System ID can be read


### PR DESCRIPTION
This change removes references to the .registered file, and instead uses the API to check registration status. If the .registered file is required for backwards compatibility reasons then modifications can be made. 