### PR TITLE
Change uppercase to lowercase 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ Example Playbook
 
     - hosts: all
       roles:
-      - { role: RedHatInsights.insights-client, when: ansible_os_family == 'RedHat' }
+      - { role: redhatinsights.insights-client, when: ansible_os_family == 'RedHat' }
 
 If a system's hostname is not easily identifiable, but inventory_hostname is easily identifiable,
 as often happens on some cloud platforms, set insights_display_name set to be inventory_hostname:
 
     - hosts: all
       roles:
-      - role: RedHatInsights.insights-client
+      - role: redhatinsights.insights-client
         insights_display_name: "{{ inventory_hostname }}"
         when: ansible_os_family == 'RedHat'
 
@@ -119,7 +119,7 @@ Example Use
 1. On a system where [Ansible is installed](http://docs.ansible.com/ansible/intro_installation.html), run the following command:
 
     ```bash
-    $ ansible-galaxy install RedHatInsights.insights-client
+    $ ansible-galaxy install redhatinsights.insights-client
     ```
 
 1. Copy the Example Playbook to a file named 'install-insights.yml'.

--- a/examples/example-insights-client-playbook.yml
+++ b/examples/example-insights-client-playbook.yml
@@ -1,4 +1,4 @@
 ---
 - hosts: all
   roles:
-  - { role: RedHatInsights.insights-client }
+  - { role: redhatinsights.insights-client }


### PR DESCRIPTION
~~~
# ansible-playbook --connection=local  /etc/ansible/install-insights.yml

ERROR! the role 'RedHatInsights.insights-client' was not found in /etc/ansible/roles:/etc/ansible/roles:/usr/share/ansible/roles:/etc/ansible

The error appears to have been in '/etc/ansible/install-insights.yml': line 4, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  roles:
  - { role: RedHatInsights.insights-client }
    ^ here
~~~

This is because the role is in lowercase:
~~~
[root@host redhatinsights.insights-client]# ls /etc/ansible/roles/
redhatinsights.insights-client
~~~