### PR TITLE
adding `no_log: true` to avoid leaking redhat_portal_password

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
     display_name: "{{ insights_display_name | default(omit) }}"
     proxy: "{{ insights_proxy | default(omit) }}"
   become: true
+  no_log: true
 
 - name: Register Insights Client
   insights_register:


### PR DESCRIPTION
Without this a malicious user can potentially see redhat_portal_password in clear text in ansible-playbook output or logs