### PR TITLE
allow all access directory for custom fatcs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
 #     limitations under the License.
 #
 - name: Install 'insights-client'
-  yum:
+  ansible.builtin.yum:
     name: insights-client
   become: true
 
 - name: Set Insights Configuration Values
-  insights_config:
+  redhatinsights.insights.insights_config:
     username: "{{ redhat_portal_username | default(omit) }}"
     password: "{{ redhat_portal_password | default(omit) }}"
     auto_config: "{{ auto_config | default(omit) }}"
@@ -30,24 +30,24 @@
   become: true
 
 - name: Register Insights Client
-  insights_register:
+  redhatinsights.insights.insights_register:
     state: present
   become: true
 
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
-  file:
+  ansible.builtin.file:
     path: /etc/insights-client
     mode: og=rx
   become: true
 
 - name: Change permissions of machine_id file so that Insights System ID can be read
-  file:
+  ansible.builtin.file:
     path: /etc/insights-client/machine-id
     mode: og=r
   become: true
 
 - name: Create directory for ansible custom facts
-  file:
+  ansible.builtin.file:
     state: directory
     recurse: true
     path: /etc/ansible/facts.d
@@ -55,7 +55,7 @@
   become: true
 
 - name: Install custom insights fact
-  copy:
+  ansible.builtin.copy:
     src: insights.fact
     dest: /etc/ansible/facts.d
     mode: a+rx

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   insights_register:
     state: present
   become: true
-  
+
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
   file:
     path: /etc/insights-client
@@ -51,11 +51,12 @@
     state: directory
     recurse: true
     path: /etc/ansible/facts.d
+    mode: a+rx
   become: true
 
 - name: Install custom insights fact
   copy:
     src: insights.fact
     dest: /etc/ansible/facts.d
-    mode: a+x
+    mode: a+rx
   become: true


### PR DESCRIPTION
When server is configured con default umask 027, `/etc/ansible/facts.d` directory is created with 750 permission and custom fact are not available when `become: false`.
This change assure correct permission.
Thanks,
Francesco